### PR TITLE
#40 While logged in, clicking on the "Bet" button on the card instantly triggers the login screen.

### DIFF
--- a/app/src/main/java/com/jiachian/nbatoday/compose/screen/card/GameCardViewModel.kt
+++ b/app/src/main/java/com/jiachian/nbatoday/compose/screen/card/GameCardViewModel.kt
@@ -43,7 +43,7 @@ class GameCardViewModel(
     // whether the user is logged in
     val login = user
         .map { it != null }
-        .stateIn(coroutineScope, SharingStarted.Lazily, false)
+        .stateIn(coroutineScope, SharingStarted.Eagerly, false)
 
     // the expanded status of the game card
     private val expandedImp = MutableStateFlow(false)


### PR DESCRIPTION
Issue #40

## Step to reproduce
1. Log in to your account.
2. Click on the "Bet" button on any card.
3. The login screen appears instantly.

## How to fix
Set SharingStarted to Eagerly.