### PR TITLE
43 send email with apk

### DIFF
--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -17,8 +17,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Build release apk
-        run: ./gradlew assembleRelease
+      #      - name: Build release apk
+      #        run: ./gradlew assembleRelease
 
       - name: Send the apk via email
         uses: dawidd6/action-send-mail@v3
@@ -31,4 +31,4 @@ jobs:
           body: Please do not reply. Check the attachment and install/update the latest version of the app.
           from: Jia Chian
           to: s2g090123@gmail.com
-          attachments: app/build/outputs/apk/release/NBAToday.apk
+#          attachments: app/build/outputs/apk/release/NBAToday.apk

--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -27,7 +27,7 @@ jobs:
           if [ -z "$version" ]; then
             version="new"
           fi
-          echo "::set-output name=release_version::${version}"
+          echo "release_version=${version}" >> $GITHUB_OUTPUT
 
       - name: echo user
         run: echo ${{secrets.OWNER_EMAIL}}

--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -43,4 +43,4 @@ jobs:
             Jia Chian
           to: s2g090123@gmail.com
           from: Jia Chian
-          attachments: app/build/outputs/apk/release/NBAToday.apk
+          attachments: app/build/outputs/apk/release/NBAToday.zip

--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -43,4 +43,4 @@ jobs:
             Jia Chian
           to: s2g090123@gmail.com
           from: Jia Chian
-          attachments: app/build/outputs/apk/release/NBAToday.zip
+          attachments: NBAToday.zip

--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -33,6 +33,13 @@ jobs:
           username: ${{secrets.MAIL_USERNAME}}
           password: ${{secrets.MAIL_PASSWORD}}
           subject: NBA Today ${{ github.event.release.tag_name }} version has been released
-          body: Please do not reply. Check the attachment and install/update the latest version of the app.
+          body: |
+            Please do not reply.
+            Check the attachment and install/update the latest version of the app.
+
+            Have a nice day! ^^
+
+            Best regards,
+            Jia Chian
           to: s2g090123@gmail.com
           attachments: app/build/outputs/apk/release/NBAToday.apk

--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -1,0 +1,31 @@
+name: Build apk and send it via email when releasing
+
+on:
+  release:
+    types:
+      - created
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Build release apk
+        run: ./gradlew assembleRelease
+
+      - name: Send the apk via email
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{secrets.MAIL_USERNAME}}
+          password: ${{secrets.MAIL_PASSWORD}}
+          subject: NBA Today ${{ github.event.release.tag_name }} version has been released
+          body: Please do not reply. Check the attachment and install/update the latest version of the app.
+          to: ${{secrets.OWNER_EMAIL}}
+          from: Jia Chian
+          attachments: app/build/outputs/apk/release/NBAToday.apk

--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -30,5 +30,5 @@ jobs:
           subject: NBA Today ${{ github.event.release.tag_name }} version has been released
           body: Please do not reply. Check the attachment and install/update the latest version of the app.
           from: Jia Chian
-          to: ${{secrets.OWNER_EMAIL}}
+          to: s2g090123@gmail.com
           attachments: app/build/outputs/apk/release/NBAToday.apk

--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -1,10 +1,10 @@
 name: Build apk and send it via email when releasing
 
 on:
-  pull_request:
-    branches:
-      - '*'
   workflow_dispatch:
+    pull_request:
+      branches:
+        - '*'
 
 jobs:
   build:
@@ -26,6 +26,6 @@ jobs:
           password: ${{secrets.MAIL_PASSWORD}}
           subject: NBA Today ${{ github.event.release.tag_name }} version has been released
           body: Please do not reply. Check the attachment and install/update the latest version of the app.
-          to: ${{secrets.OWNER_EMAIL}}
           from: Jia Chian
+          to: ${{secrets.OWNER_EMAIL}}
           attachments: app/build/outputs/apk/release/NBAToday.apk

--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -42,4 +42,5 @@ jobs:
             Best regards,
             Jia Chian
           to: s2g090123@gmail.com
+          from: Jia Chian
           attachments: app/build/outputs/apk/release/NBAToday.apk

--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -1,9 +1,6 @@
 name: Build apk and send it via email when releasing
 
 on:
-  release:
-    types:
-      - created
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -17,8 +17,13 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      #      - name: Build release apk
-      #        run: ./gradlew assembleRelease
+      - name: Build release apk
+        run: ./gradlew assembleRelease
+
+      - name: Zip the apk
+        run: |
+          rm -rf NBAToday.zip
+          zip -r NBAToday.zip app/build/outputs/apk/release/NBAToday.apk
 
       - name: Send the apk via email
         uses: dawidd6/action-send-mail@v3
@@ -29,6 +34,5 @@ jobs:
           password: ${{secrets.MAIL_PASSWORD}}
           subject: NBA Today ${{ github.event.release.tag_name }} version has been released
           body: Please do not reply. Check the attachment and install/update the latest version of the app.
-          from: Jia Chian
           to: s2g090123@gmail.com
-#          attachments: app/build/outputs/apk/release/NBAToday.apk
+          attachments: app/build/outputs/apk/release/NBAToday.apk

--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -20,12 +20,8 @@ jobs:
       - name: Build release apk
         run: ./gradlew assembleRelease
 
-      - name: Zip the apk
-        run: |
-          rm -rf NBAToday.zip
-          zip -r NBAToday.zip app/build/outputs/apk/release/NBAToday.apk
-
       - name: Send the apk via email
+        continue-on-error: true
         uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
@@ -34,7 +30,8 @@ jobs:
           password: ${{secrets.MAIL_PASSWORD}}
           subject: NBA Today ${{ github.event.release.tag_name }} version has been released
           body: |
-            Please do not reply.
+            [Please do not reply]
+
             Check the attachment and install/update the latest version of the app.
 
             Have a nice day! ^^
@@ -43,4 +40,4 @@ jobs:
             Jia Chian
           to: s2g090123@gmail.com
           from: Jia Chian
-          attachments: NBAToday.zip
+          attachments: app/build/outputs/apk/release/NBAToday.apk

--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -20,6 +20,18 @@ jobs:
       - name: Build release apk
         run: ./gradlew assembleRelease
 
+      - name: Set release version
+        id: set_release_version
+        run: |
+          version=$(echo "${{ github.event.release.tag_name }}" | tr -d '[:space:]')
+          if [ -z "$version" ]; then
+            version="new"
+          fi
+          echo "::set-output name=release_version::${version}"
+
+      - name: echo user
+        run: echo ${{secrets.OWNER_EMAIL}}
+
       - name: Send the apk via email
         continue-on-error: true
         uses: dawidd6/action-send-mail@v3
@@ -28,7 +40,7 @@ jobs:
           server_port: 465
           username: ${{secrets.MAIL_USERNAME}}
           password: ${{secrets.MAIL_PASSWORD}}
-          subject: NBA Today ${{ github.event.release.tag_name }} version has been released
+          subject: NBA Today ${{ steps.set_release_version.outputs.release_version }}" version has been released
           body: |
             [Please do not reply]
 
@@ -38,6 +50,6 @@ jobs:
 
             Best regards,
             Jia Chian
-          to: s2g090123@gmail.com
+          to: ${{secrets.OWNER_EMAIL}}
           from: Jia Chian
           attachments: app/build/outputs/apk/release/NBAToday.apk

--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -1,6 +1,9 @@
 name: Build apk and send it via email when releasing
 
 on:
+  pull_request:
+    branches:
+      - '*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -1,6 +1,9 @@
 name: Build apk and send it via email when releasing
 
 on:
+  pull_request:
+    branches:
+      - '*'
   workflow_dispatch:
     pull_request:
       branches:

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ gen/
 
 # Local configuration file (sdk path, etc)
 local.properties
+keystore.properties
+*.jks
 
 # Windows thumbnail db
 Thumbs.db

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,6 +7,22 @@ apply from: "../buildscripts/jacoco.gradle"
 apply from: "../buildscripts/detekt.gradle"
 apply from: "../buildscripts/ktlint.gradle"
 
+def getOutputFileName(outputFileName, versionName) {
+  String fileName = outputFileName.toLowerCase()
+  String fileExtension = fileName.substring(fileName.lastIndexOf('.') + 1)
+  if (fileExtension == 'apk' || fileExtension == 'aab') {
+    return "NBAToday.${fileExtension}"
+  } else {
+    return outputFileName
+  }
+}
+
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file('keystore.properties')
+if (keystorePropertiesFile.exists()) {
+  keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 android {
   compileSdk 33
 
@@ -23,10 +39,25 @@ android {
     }
   }
 
+  signingConfigs {
+    release {
+      keyAlias keystoreProperties['keyAlias']
+      keyPassword keystoreProperties['keyAlias.password']
+      storeFile keystoreProperties['keystore'] ? file(keystoreProperties['keystore']) : null
+      storePassword keystoreProperties['keystore.password']
+    }
+  }
+
   buildTypes {
     release {
       minifyEnabled false
       proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+
+      android.applicationVariants.all { variant ->
+        variant.outputs.all {
+          outputFileName = getOutputFileName(outputFileName, variant.versionName)
+        }
+      }
     }
     debug {
       testCoverageEnabled true
@@ -130,4 +161,26 @@ dependencies {
   androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutine_version"
   androidTestImplementation "io.mockk:mockk-android:$mockk_version"
   androidTestImplementation "androidx.navigation:navigation-testing:$nav_version"
+}
+
+// Rename generated aab
+tasks.whenTaskAdded { task ->
+  def taskName = task.name
+  //Skip some unnecessary tasks
+  if (taskName.startsWith("bundle") && taskName.endsWith("Release")) {
+    def renameTaskName = "rename${task.name.capitalize()}Aab"
+    def flavor = taskName.substring("bundle".length())
+    def versionName = android.defaultConfig.versionName
+    def outputName = getOutputFileName(".aab", versionName)
+    tasks.create(renameTaskName) {
+      def path = "${rootDir}/../build/app/outputs/bundle/${flavor}"
+      def originalFile = "$path/app-release.aab"
+      doLast {
+        if (file("$originalFile").exists()) {
+          ant.move file: "$originalFile", tofile: "$path/${outputName}"
+        }
+      }
+    }
+    task.finalizedBy(renameTaskName)
+  }
 }


### PR DESCRIPTION
Issue #43 

## Description
1. When released, generate the apk and send it via email.

## How to implement
1. Create a `build_apk` workflow, and when released or manually triggered, generate the APK and send it via email.

## Changes
1. Update the `build.gradle`
   - Add signingConfigs
   - Update the name of the generated apk
