### PR TITLE
43 send email with apk

### DIFF
--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -1,0 +1,31 @@
+name: Build apk and send it via email when releasing
+
+on:
+  release:
+    types:
+      - created
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Build release apk
+        run: ./gradlew assembleRelease
+
+      - name: Send the apk via email
+        uses: dawidd6/action-send-mail@v3
+        with:
+          server_address: smtp.gmail.com
+          server_port: 465
+          username: ${{secrets.MAIL_USERNAME}}
+          password: ${{secrets.MAIL_PASSWORD}}
+          subject: NBA Today ${{ github.event.release.tag_name }} version has been released
+          body: Please do not reply. Check the attachment and install/update the latest version of the app.
+          to: ${{secrets.OWNER_EMAIL}}
+          from: Jia Chian
+          attachments: app/build/outputs/apk/release/NBAToday.apk

--- a/.github/workflows/build_apk.yml
+++ b/.github/workflows/build_apk.yml
@@ -17,15 +17,33 @@ jobs:
       - name: Build release apk
         run: ./gradlew assembleRelease
 
+      - name: Set release version
+        id: set_release_version
+        run: |
+          version=$(echo "${{ github.event.release.tag_name }}" | tr -d '[:space:]')
+          if [ -z "$version" ]; then
+            version="new"
+          fi
+          echo "release_version=${version}" >> $GITHUB_OUTPUT
+
       - name: Send the apk via email
+        continue-on-error: true
         uses: dawidd6/action-send-mail@v3
         with:
           server_address: smtp.gmail.com
           server_port: 465
           username: ${{secrets.MAIL_USERNAME}}
           password: ${{secrets.MAIL_PASSWORD}}
-          subject: NBA Today ${{ github.event.release.tag_name }} version has been released
-          body: Please do not reply. Check the attachment and install/update the latest version of the app.
+          subject: NBA Today ${{ steps.set_release_version.outputs.release_version }} version has been released
+          body: |
+            [Please do not reply]
+
+            Check the attachment and install/update the latest version of the app.
+
+            Have a nice day! ^^
+
+            Best regards,
+            Jia Chian
           to: ${{secrets.OWNER_EMAIL}}
           from: Jia Chian
           attachments: app/build/outputs/apk/release/NBAToday.apk

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ gen/
 
 # Local configuration file (sdk path, etc)
 local.properties
+keystore.properties
+*.jks
 
 # Windows thumbnail db
 Thumbs.db

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,6 +7,22 @@ apply from: "../buildscripts/jacoco.gradle"
 apply from: "../buildscripts/detekt.gradle"
 apply from: "../buildscripts/ktlint.gradle"
 
+def getOutputFileName(outputFileName, versionName) {
+  String fileName = outputFileName.toLowerCase()
+  String fileExtension = fileName.substring(fileName.lastIndexOf('.') + 1)
+  if (fileExtension == 'apk' || fileExtension == 'aab') {
+    return "NBAToday.${fileExtension}"
+  } else {
+    return outputFileName
+  }
+}
+
+def keystoreProperties = new Properties()
+def keystorePropertiesFile = rootProject.file('keystore.properties')
+if (keystorePropertiesFile.exists()) {
+  keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
 android {
   compileSdk 33
 
@@ -23,10 +39,25 @@ android {
     }
   }
 
+  signingConfigs {
+    release {
+      keyAlias keystoreProperties['keyAlias']
+      keyPassword keystoreProperties['keyAlias.password']
+      storeFile keystoreProperties['keystore'] ? file(keystoreProperties['keystore']) : null
+      storePassword keystoreProperties['keystore.password']
+    }
+  }
+
   buildTypes {
     release {
       minifyEnabled false
       proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+
+      android.applicationVariants.all { variant ->
+        variant.outputs.all {
+          outputFileName = getOutputFileName(outputFileName, variant.versionName)
+        }
+      }
     }
     debug {
       testCoverageEnabled true
@@ -130,4 +161,26 @@ dependencies {
   androidTestImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutine_version"
   androidTestImplementation "io.mockk:mockk-android:$mockk_version"
   androidTestImplementation "androidx.navigation:navigation-testing:$nav_version"
+}
+
+// Rename generated aab
+tasks.whenTaskAdded { task ->
+  def taskName = task.name
+  //Skip some unnecessary tasks
+  if (taskName.startsWith("bundle") && taskName.endsWith("Release")) {
+    def renameTaskName = "rename${task.name.capitalize()}Aab"
+    def flavor = taskName.substring("bundle".length())
+    def versionName = android.defaultConfig.versionName
+    def outputName = getOutputFileName(".aab", versionName)
+    tasks.create(renameTaskName) {
+      def path = "${rootDir}/../build/app/outputs/bundle/${flavor}"
+      def originalFile = "$path/app-release.aab"
+      doLast {
+        if (file("$originalFile").exists()) {
+          ant.move file: "$originalFile", tofile: "$path/${outputName}"
+        }
+      }
+    }
+    task.finalizedBy(renameTaskName)
+  }
 }


### PR DESCRIPTION
Issue #43 

## Description
1. When released, generate the apk and send it via email.

## How to implement
1. Create a `build_apk` workflow, and when released or manually triggered, generate the APK and send it via email.

## Changes
1. Update the `build.gradle`
   - Add signingConfigs
   - Update the name of the generated apk