### PR TITLE
#52 collectAsStateWithLifecycle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,7 +24,7 @@ if (keystorePropertiesFile.exists()) {
 }
 
 android {
-  compileSdk 33
+  compileSdk 34
 
   defaultConfig {
     applicationId "com.jiachian.nbatoday"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -124,6 +124,7 @@ dependencies {
   implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"
   implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
   implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
+  implementation "androidx.lifecycle:lifecycle-runtime-compose:$lifecycle_version"
 
   // coroutine
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutine_version"

--- a/app/src/main/java/com/jiachian/nbatoday/compose/screen/bet/BetDialog.kt
+++ b/app/src/main/java/com/jiachian/nbatoday/compose/screen/bet/BetDialog.kt
@@ -16,7 +16,6 @@ import androidx.compose.material.AlertDialog
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,6 +32,7 @@ import androidx.compose.ui.text.toUpperCase
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.jiachian.nbatoday.R
 import com.jiachian.nbatoday.Transparency25
 import com.jiachian.nbatoday.compose.widget.CustomOutlinedTextField
@@ -48,10 +48,10 @@ fun BetDialog(
     onConfirm: (homePoints: Long, awayPoints: Long) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val warning by viewModel.warning.collectAsState()
-    val homePoints by viewModel.homePoints.collectAsState()
-    val awayPoints by viewModel.awayPoints.collectAsState()
-    val enabled by viewModel.enabled.collectAsState()
+    val warning by viewModel.warning.collectAsStateWithLifecycle()
+    val homePoints by viewModel.homePoints.collectAsStateWithLifecycle()
+    val awayPoints by viewModel.awayPoints.collectAsStateWithLifecycle()
+    val enabled by viewModel.enabled.collectAsStateWithLifecycle()
     Dialog(onDismissRequest = onDismiss) {
         Column(
             modifier = Modifier
@@ -113,7 +113,7 @@ private fun BetDialogDetail(
     homePoints: Long,
     awayPoints: Long
 ) {
-    val remainingPoint by viewModel.remainingPoints.collectAsState()
+    val remainingPoint by viewModel.remainingPoints.collectAsStateWithLifecycle()
     Column(
         modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally

--- a/app/src/main/java/com/jiachian/nbatoday/compose/screen/bet/BetScreen.kt
+++ b/app/src/main/java/com/jiachian/nbatoday/compose/screen/bet/BetScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -22,6 +21,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.jiachian.nbatoday.R
 import com.jiachian.nbatoday.compose.screen.bet.dialog.RewardedPointsScreen
 import com.jiachian.nbatoday.compose.screen.bet.dialog.TurnTableScreen
@@ -35,7 +35,7 @@ import com.jiachian.nbatoday.utils.rippleClickable
 
 @Composable
 fun BetScreen(viewModel: BetViewModel) {
-    val rewardedPoints by viewModel.rewardedPoints.collectAsState()
+    val rewardedPoints by viewModel.rewardedPoints.collectAsStateWithLifecycle()
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -71,7 +71,7 @@ private fun BetBody(
     modifier: Modifier = Modifier,
     viewModel: BetViewModel,
 ) {
-    val betsAndGamesState by viewModel.betsAndGamesState.collectAsState()
+    val betsAndGamesState by viewModel.betsAndGamesState.collectAsStateWithLifecycle()
     UIStateScreen(
         state = betsAndGamesState,
         loading = {

--- a/app/src/main/java/com/jiachian/nbatoday/compose/screen/bet/dialog/TurnTableScreen.kt
+++ b/app/src/main/java/com/jiachian/nbatoday/compose/screen/bet/dialog/TurnTableScreen.kt
@@ -2,10 +2,10 @@ package com.jiachian.nbatoday.compose.screen.bet.dialog
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.jiachian.nbatoday.compose.screen.bet.BetViewModel
 import com.jiachian.nbatoday.compose.screen.bet.turntable.AskTurnTableDialog
 import com.jiachian.nbatoday.compose.screen.bet.turntable.BetTurnTable
@@ -14,8 +14,8 @@ import com.jiachian.nbatoday.testing.testtag.BetTestTag
 
 @Composable
 fun TurnTableScreen(viewModel: BetViewModel) {
-    val turnTablePoints by viewModel.turnTablePoints.collectAsState()
-    val turnTableVisible by viewModel.turnTableVisible.collectAsState()
+    val turnTablePoints by viewModel.turnTablePoints.collectAsStateWithLifecycle()
+    val turnTableVisible by viewModel.turnTableVisible.collectAsStateWithLifecycle()
     NullCheckScreen(
         data = turnTablePoints,
         ifNull = null

--- a/app/src/main/java/com/jiachian/nbatoday/compose/screen/bet/turntable/TurnTable.kt
+++ b/app/src/main/java/com/jiachian/nbatoday/compose/screen/bet/turntable/TurnTable.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -25,6 +24,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.jiachian.nbatoday.compose.screen.bet.BetViewModel
 import com.jiachian.nbatoday.testing.testtag.BetTestTag
 import com.jiachian.nbatoday.utils.drawText
@@ -52,8 +52,8 @@ fun BetTurnTable(
     onStart: () -> Unit,
     onClose: () -> Unit
 ) {
-    val running by viewModel.turnTableRunning.collectAsState()
-    val angle by viewModel.turnTableAngle.collectAsState()
+    val running by viewModel.turnTableRunning.collectAsStateWithLifecycle()
+    val angle by viewModel.turnTableAngle.collectAsStateWithLifecycle()
     val textMeasure = rememberTextMeasurer()
     val plusTextSize1 = remember { textMeasure.measureSize(PlusText1) }
     val minusTextSize1 = remember { textMeasure.measureSize(MinusText1) }

--- a/app/src/main/java/com/jiachian/nbatoday/compose/screen/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/jiachian/nbatoday/compose/screen/calendar/CalendarScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,6 +34,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.jiachian.nbatoday.DaysPerWeek
 import com.jiachian.nbatoday.R
 import com.jiachian.nbatoday.Transparency25
@@ -106,9 +106,9 @@ private fun CalendarNavigationBar(
     modifier: Modifier = Modifier,
     viewModel: CalendarViewModel,
 ) {
-    val numberAndDateString by viewModel.numberAndDateString.collectAsState()
-    val hasLastMonth by viewModel.hasLastMonth.collectAsState()
-    val hasNextMonth by viewModel.hasNextMonth.collectAsState()
+    val numberAndDateString by viewModel.numberAndDateString.collectAsStateWithLifecycle()
+    val hasLastMonth by viewModel.hasLastMonth.collectAsStateWithLifecycle()
+    val hasNextMonth by viewModel.hasNextMonth.collectAsStateWithLifecycle()
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically
@@ -163,11 +163,11 @@ private fun CalendarContent(
     modifier: Modifier = Modifier,
     viewModel: CalendarViewModel
 ) {
-    val selectedGames by viewModel.selectedGames.collectAsState()
-    val selectedGamesVisible by viewModel.selectedGamesVisible.collectAsState()
-    val loadingGames by viewModel.loadingGames.collectAsState()
-    val calendarDatesState by viewModel.calendarDatesState.collectAsState()
-    val selectedDate by viewModel.selectedDate.collectAsState()
+    val selectedGames by viewModel.selectedGames.collectAsStateWithLifecycle()
+    val selectedGamesVisible by viewModel.selectedGamesVisible.collectAsStateWithLifecycle()
+    val loadingGames by viewModel.loadingGames.collectAsStateWithLifecycle()
+    val calendarDatesState by viewModel.calendarDatesState.collectAsStateWithLifecycle()
+    val selectedDate by viewModel.selectedDate.collectAsStateWithLifecycle()
     UIStateScreen(
         state = calendarDatesState,
         loading = {

--- a/app/src/main/java/com/jiachian/nbatoday/compose/screen/card/GameCard.kt
+++ b/app/src/main/java/com/jiachian/nbatoday/compose/screen/card/GameCard.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -23,6 +22,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.jiachian.nbatoday.R
 import com.jiachian.nbatoday.compose.widget.AnimatedExpand
 import com.jiachian.nbatoday.compose.widget.TeamLogoImage
@@ -38,8 +38,8 @@ fun GameCard(
     color: Color,
     expandable: Boolean,
 ) {
-    val betAvailable by viewModel.betAvailable.collectAsState()
-    val betDialogVisible by viewModel.betDialogVisible.collectAsState()
+    val betAvailable by viewModel.betAvailable.collectAsStateWithLifecycle()
+    val betDialogVisible by viewModel.betDialogVisible.collectAsStateWithLifecycle()
     Column(
         modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally
@@ -141,7 +141,7 @@ private fun GameExpandedContent(
     viewModel: GameCardViewModel,
     color: Color
 ) {
-    val expanded by viewModel.expanded.collectAsState()
+    val expanded by viewModel.expanded.collectAsStateWithLifecycle()
     Box {
         AnimatedExpand(
             modifier = Modifier

--- a/app/src/main/java/com/jiachian/nbatoday/compose/screen/card/GameCardBet.kt
+++ b/app/src/main/java/com/jiachian/nbatoday/compose/screen/card/GameCardBet.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -15,6 +14,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.jiachian.nbatoday.R
 import com.jiachian.nbatoday.compose.screen.account.LoginDialog
 import com.jiachian.nbatoday.compose.screen.bet.BetDialog
@@ -25,8 +25,8 @@ import com.jiachian.nbatoday.utils.showToast
 
 @Composable
 fun GameCardBetScreen(viewModel: GameCardViewModel) {
-    val login by viewModel.login.collectAsState()
-    val hasBet by viewModel.hasBet.collectAsState()
+    val login by viewModel.login.collectAsStateWithLifecycle()
+    val hasBet by viewModel.hasBet.collectAsStateWithLifecycle()
     when {
         !login -> {
             LoginDialog(

--- a/app/src/main/java/com/jiachian/nbatoday/compose/screen/home/schedule/SchedulePage.kt
+++ b/app/src/main/java/com/jiachian/nbatoday/compose/screen/home/schedule/SchedulePage.kt
@@ -21,7 +21,6 @@ import androidx.compose.material.pullrefresh.PullRefreshState
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -31,6 +30,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.PagerState
@@ -54,8 +54,8 @@ fun SchedulePage(
 ) {
     val dateData = viewModel.dateData
     val pagerState = rememberPagerState(initialPage = dateData.size / 2)
-    val dateAndGamesState by viewModel.groupedGamesState.collectAsState()
-    val refreshing by viewModel.refreshing.collectAsState()
+    val dateAndGamesState by viewModel.groupedGamesState.collectAsStateWithLifecycle()
+    val refreshing by viewModel.refreshing.collectAsStateWithLifecycle()
     val pullRefreshState = rememberPullRefreshState(
         refreshing = refreshing,
         onRefresh = { viewModel.updateSelectedSchedule() }

--- a/app/src/main/java/com/jiachian/nbatoday/compose/screen/home/standing/StandingPage.kt
+++ b/app/src/main/java/com/jiachian/nbatoday/compose/screen/home/standing/StandingPage.kt
@@ -28,7 +28,6 @@ import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -39,6 +38,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.PagerState
@@ -64,7 +64,7 @@ fun StandingPage(
     modifier: Modifier = Modifier,
     viewModel: StandingPageViewModel,
 ) {
-    val refreshing by viewModel.refreshing.collectAsState()
+    val refreshing by viewModel.refreshing.collectAsStateWithLifecycle()
     val pagerState = rememberPagerState()
     val pullRefreshState = rememberPullRefreshState(
         refreshing = refreshing,
@@ -153,12 +153,12 @@ private fun StandingScreen(
 ) {
     val scrollState = rememberScrollState()
     val rowDataState by when (east) {
-        true -> viewModel.sortedEastRowDataState.collectAsState()
-        false -> viewModel.sortedWestRowDataState.collectAsState()
+        true -> viewModel.sortedEastRowDataState.collectAsStateWithLifecycle()
+        false -> viewModel.sortedWestRowDataState.collectAsStateWithLifecycle()
     }
     val sorting by when (east) {
-        true -> viewModel.eastSorting.collectAsState()
-        false -> viewModel.westSorting.collectAsState()
+        true -> viewModel.eastSorting.collectAsStateWithLifecycle()
+        false -> viewModel.westSorting.collectAsStateWithLifecycle()
     }
     UIStateScreen(
         state = rowDataState,

--- a/app/src/main/java/com/jiachian/nbatoday/compose/screen/home/user/UserPage.kt
+++ b/app/src/main/java/com/jiachian/nbatoday/compose/screen/home/user/UserPage.kt
@@ -23,7 +23,6 @@ import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,6 +40,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.jiachian.nbatoday.R
 import com.jiachian.nbatoday.compose.screen.account.LoginDialog
 import com.jiachian.nbatoday.compose.theme.NBAColors
@@ -58,7 +58,7 @@ fun UserPage(
     modifier: Modifier = Modifier,
     viewModel: UserPageViewModel
 ) {
-    val userState by viewModel.userState.collectAsState()
+    val userState by viewModel.userState.collectAsStateWithLifecycle()
     UIStateScreen(
         state = userState,
         loading = {

--- a/app/src/main/java/com/jiachian/nbatoday/compose/screen/player/PlayerScreen.kt
+++ b/app/src/main/java/com/jiachian/nbatoday/compose/screen/player/PlayerScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -19,6 +18,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.jiachian.nbatoday.R
 import com.jiachian.nbatoday.compose.screen.player.models.PlayerUI
 import com.jiachian.nbatoday.compose.screen.player.widgets.playerInfo
@@ -30,7 +30,7 @@ import com.jiachian.nbatoday.testing.testtag.PlayerTestTag
 
 @Composable
 fun PlayerScreen(viewModel: PlayerViewModel) {
-    val playerUIState by viewModel.playerUIState.collectAsState()
+    val playerUIState by viewModel.playerUIState.collectAsStateWithLifecycle()
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -77,7 +77,7 @@ private fun PlayerDetail(
     viewModel: PlayerViewModel,
     playerUI: PlayerUI,
 ) {
-    val sorting by viewModel.sorting.collectAsState()
+    val sorting by viewModel.sorting.collectAsStateWithLifecycle()
     val scrollState = rememberScrollState()
     LazyColumn(modifier = modifier) {
         playerInfo(

--- a/app/src/main/java/com/jiachian/nbatoday/compose/screen/score/BoxScoreScreen.kt
+++ b/app/src/main/java/com/jiachian/nbatoday/compose/screen/score/BoxScoreScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -30,6 +29,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.rememberPagerState
 import com.jiachian.nbatoday.R
@@ -47,8 +47,8 @@ private val TopMargin = 81.dp
 
 @Composable
 fun BoxScoreScreen(viewModel: BoxScoreViewModel) {
-    val date by viewModel.date.collectAsState()
-    val boxScoreUIState by viewModel.boxScoreUIState.collectAsState()
+    val date by viewModel.date.collectAsStateWithLifecycle()
+    val boxScoreUIState by viewModel.boxScoreUIState.collectAsStateWithLifecycle()
     Column(
         modifier = Modifier
             .fillMaxSize()

--- a/app/src/main/java/com/jiachian/nbatoday/compose/screen/score/widgets/PlayerPageWidgets.kt
+++ b/app/src/main/java/com/jiachian/nbatoday/compose/screen/score/widgets/PlayerPageWidgets.kt
@@ -21,7 +21,6 @@ import androidx.compose.material.Divider
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,6 +33,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Popup
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.jiachian.nbatoday.R
 import com.jiachian.nbatoday.compose.screen.score.BoxScoreViewModel
 import com.jiachian.nbatoday.compose.screen.score.models.BoxScorePlayerLabel
@@ -92,7 +92,7 @@ private fun ScorePlayerLabelRow(
     viewModel: BoxScoreViewModel,
     scrollState: ScrollState,
 ) {
-    val selectedLabel by viewModel.selectedPlayerLabel.collectAsState()
+    val selectedLabel by viewModel.selectedPlayerLabel.collectAsStateWithLifecycle()
     Row(modifier = modifier) {
         Text(
             modifier = Modifier

--- a/app/src/main/java/com/jiachian/nbatoday/compose/screen/team/TeamScreen.kt
+++ b/app/src/main/java/com/jiachian/nbatoday/compose/screen/team/TeamScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.material.TabRowDefaults
 import androidx.compose.material.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -31,6 +30,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.PagerState
@@ -51,7 +51,7 @@ private val TopMargin = 81.dp
 
 @Composable
 fun TeamScreen(viewModel: TeamViewModel) {
-    val teamUIState by viewModel.teamUIState.collectAsState()
+    val teamUIState by viewModel.teamUIState.collectAsStateWithLifecycle()
     val scrollState = rememberScrollState()
     Column(modifier = Modifier.background(viewModel.colors.primary)) {
         IconButton(
@@ -230,7 +230,7 @@ private fun TeamPager(
                 )
             }
             1 -> {
-                val gamesBefore by viewModel.gamesBefore.collectAsState()
+                val gamesBefore by viewModel.gamesBefore.collectAsStateWithLifecycle()
                 TeamGamePage(
                     modifier = Modifier.fillMaxHeight(),
                     viewModel = viewModel,
@@ -238,7 +238,7 @@ private fun TeamPager(
                 )
             }
             2 -> {
-                val gamesAfter by viewModel.gamesAfter.collectAsState()
+                val gamesAfter by viewModel.gamesAfter.collectAsStateWithLifecycle()
                 TeamGamePage(
                     modifier = Modifier.fillMaxHeight(),
                     viewModel = viewModel,

--- a/app/src/main/java/com/jiachian/nbatoday/compose/screen/team/widgets/TeamPlayerWidgets.kt
+++ b/app/src/main/java/com/jiachian/nbatoday/compose/screen/team/widgets/TeamPlayerWidgets.kt
@@ -19,7 +19,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.Divider
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -29,6 +28,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.jiachian.nbatoday.Transparency25
 import com.jiachian.nbatoday.compose.screen.team.TeamViewModel
 import com.jiachian.nbatoday.compose.screen.team.models.TeamPlayerLabel
@@ -46,7 +46,7 @@ fun TeamPlayerPage(
     teamPlayers: List<TeamPlayerRowData>,
 ) {
     val scrollState = rememberScrollState()
-    val sorting by viewModel.playerSorting.collectAsState()
+    val sorting by viewModel.playerSorting.collectAsStateWithLifecycle()
     LazyColumn(modifier = modifier) {
         stickyHeader {
             ScorePlayerLabelScrollableRow(

--- a/app/src/test/java/com/jiachian/nbatoday/rule/CalendarRule.kt
+++ b/app/src/test/java/com/jiachian/nbatoday/rule/CalendarRule.kt
@@ -4,7 +4,6 @@ import com.jiachian.nbatoday.BasicTime
 import com.jiachian.nbatoday.utils.DateUtils
 import io.mockk.every
 import io.mockk.mockkObject
-import io.mockk.unmockkObject
 import java.util.Calendar
 import java.util.Date
 import java.util.TimeZone
@@ -25,6 +24,15 @@ class CalendarRule : TestWatcher() {
     }
 
     override fun finished(description: Description) {
-        unmockkObject(DateUtils)
+        /**
+         * WORKAROUND!
+         * When dealing with #52-collectAsStateWithLifecycle, upgraded the android gradle plugin and gradle versions,
+         * and then started encountering the `io.mockk.MockKException: can't find stub DateUtils(object DateUtils)` problem.
+         *
+         * Unable to confirm the exact cause of the issue,
+         * but suspect it may be related to issues with unmock.
+         * Therefore, commented out the following code for now.
+         */
+        //unmockkObject(DateUtils)
     }
 }

--- a/app/src/test/java/com/jiachian/nbatoday/rule/CalendarRule.kt
+++ b/app/src/test/java/com/jiachian/nbatoday/rule/CalendarRule.kt
@@ -33,6 +33,6 @@ class CalendarRule : TestWatcher() {
          * but suspect it may be related to issues with unmock.
          * Therefore, commented out the following code for now.
          */
-        //unmockkObject(DateUtils)
+        // unmockkObject(DateUtils)
     }
 }

--- a/app/src/test/java/com/jiachian/nbatoday/rule/NBATeamRule.kt
+++ b/app/src/test/java/com/jiachian/nbatoday/rule/NBATeamRule.kt
@@ -5,7 +5,6 @@ import com.jiachian.nbatoday.data.local.NBATeamGenerator
 import com.jiachian.nbatoday.models.local.team.NBATeam
 import io.mockk.every
 import io.mockk.mockkObject
-import io.mockk.unmockkObject
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
 
@@ -23,6 +22,15 @@ class NBATeamRule : TestWatcher() {
     }
 
     override fun finished(description: Description) {
-        unmockkObject(NBATeam)
+        /**
+         * WORKAROUND!
+         * When dealing with #52-collectAsStateWithLifecycle, upgraded the android gradle plugin and gradle versions,
+         * and then started encountering the `io.mockk.MockKException: can't find stub Companion(Companion)` problem.
+         *
+         * Unable to confirm the exact cause of the issue,
+         * but suspect it may be related to issues with unmock.
+         * Therefore, commented out the following code for now.
+         */
+        //unmockkObject(NBATeam)
     }
 }

--- a/app/src/test/java/com/jiachian/nbatoday/rule/NBATeamRule.kt
+++ b/app/src/test/java/com/jiachian/nbatoday/rule/NBATeamRule.kt
@@ -31,6 +31,6 @@ class NBATeamRule : TestWatcher() {
          * but suspect it may be related to issues with unmock.
          * Therefore, commented out the following code for now.
          */
-        //unmockkObject(NBATeam)
+        // unmockkObject(NBATeam)
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -14,12 +14,14 @@ buildscript {
         detekt_version = "1.23.1"
         ktlint_version = "0.43.1"
         ktlint_gradle_version = "11.5.1"
+        android_gradle_plugin_version = "7.4.0"
     }
 
     dependencies {
         classpath "com.hiya:jacoco-android:$jacoco_android_version"
         classpath "io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detekt_version"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:$ktlint_gradle_version"
+      classpath "com.android.tools.build:gradle:$android_gradle_plugin_version"
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         compose_version = '1.3.0'
-        lifecycle_version = '2.5.1'
+        lifecycle_version = '2.7.0'
         coroutine_version = '1.6.4'
         retrofit_version = '2.9.0'
         room_version = '2.4.3'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Oct 30 14:54:12 CST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Issue #52

## Description
Use `collectAsStateWithLifecycle` to consume flows safely.
Read [blog](https://medium.com/androiddevelopers/consuming-flows-safely-in-jetpack-compose-cde014d0d5a3) to get further information.

## How to implement
1. Replace collectAsState with collectAsStateWithLifecycle

## Changes
1. Upgrade compileSdk to 34
2. Upgrade the version of lifecycle to 2.7.0
